### PR TITLE
Display yellow stroke around local participant

### DIFF
--- a/services/conference/src/scripts/components/map/ParticipantsLayer/LocalParticipant.tsx
+++ b/services/conference/src/scripts/components/map/ParticipantsLayer/LocalParticipant.tsx
@@ -1,5 +1,6 @@
 import {useStore} from '@hooks/ParticipantsStore'
 import {memoComponent} from '@hooks/utils'
+import {makeStyles} from '@material-ui/core/styles'
 import {useObserver} from 'mobx-react-lite'
 import React, {useEffect, useRef} from 'react'
 import {addV, subV, useGesture} from 'react-use-gesture'
@@ -15,6 +16,18 @@ const LocalParticipant: React.FC<LocalParticipantProps> = (props) => {
     position: participant.pose.position,
     orientation: participant.pose.orientation,
   }))
+
+  const useStyles = makeStyles({
+    local: () => ({
+      '& .participantWrapper': {
+        '& circle, & path': {
+          stroke: '#e5da00',
+        },
+      },
+    }),
+  })
+
+  const classes = useStyles()
 
   const transform = useTransform()
 
@@ -46,7 +59,9 @@ const LocalParticipant: React.FC<LocalParticipantProps> = (props) => {
   )
 
   return (
-    <Participant {...props} ref={container} />
+    <div className={classes.local}>
+      <Participant {...props} ref={container} />
+    </div>
   )
 }
 

--- a/services/conference/src/scripts/components/map/ParticipantsLayer/Participant.tsx
+++ b/services/conference/src/scripts/components/map/ParticipantsLayer/Participant.tsx
@@ -74,11 +74,13 @@ const RawParticipant: React.ForwardRefRenderFunction<HTMLDivElement , Participan
           right: -pointerAvatarRatio * props.size / 2,
         }}
       >
-          <div className={classes.pointerRotate}>
-            <Pointer className={classes.pointer} />
-          </div>
-          <div className={[classes.avatar, transform.counterRotationClass].join(' ')}>
-            <Avatar {...props} />
+          <div className="participantWrapper">
+            <div className={classes.pointerRotate}>
+              <Pointer className={classes.pointer} />
+            </div>
+            <div className={[classes.avatar, transform.counterRotationClass].join(' ')}>
+              <Avatar {...props} />
+            </div>
           </div>
           {showConfig ? configuration : null}
       </MapObjectContainer >


### PR DESCRIPTION
Source issue: https://github.com/JitsiPartyTeam/jitsi-party/issues/25

This PR adds a yellow stroke around the local participant by using styles in the LocalParticipant component.

<img width="374" alt="Screenshot 2020-06-28 at 20 34 56" src="https://user-images.githubusercontent.com/1074181/85955661-6df5d000-b980-11ea-9371-deaf82f1dfa5.png">
