### PR TITLE
Reduce drag start area of local participant

### DIFF
--- a/services/conference/package.json
+++ b/services/conference/package.json
@@ -80,6 +80,7 @@
     "react-avatar": "^3.9.3",
     "react-dimensions-hook": "https://github.com/hasevr/react-dimensions-hook.git",
     "react-dom": "^16.13.1",
+    "react-draggable": "^4.4.3",
     "react-rnd": "https://github.com/hasevr/react-rnd.git",
     "react-use-gesture": "^7.0.15",
     "tern": "^0.24.3",

--- a/services/conference/src/scripts/components/map/ParticipantsLayer/LocalParticipant.tsx
+++ b/services/conference/src/scripts/components/map/ParticipantsLayer/LocalParticipant.tsx
@@ -41,7 +41,7 @@ const LocalParticipant: React.FC<LocalParticipantProps> = (props) => {
   }
 
   return (
-    <DraggableCore handle=".handle, path" onDrag={dragEventHandler}>
+    <DraggableCore handle=".draggableHandle, path" onDrag={dragEventHandler}>
       <div className={classes.local}>
         <Participant {...props} />
       </div>

--- a/services/conference/src/scripts/components/map/ParticipantsLayer/LocalParticipant.tsx
+++ b/services/conference/src/scripts/components/map/ParticipantsLayer/LocalParticipant.tsx
@@ -41,7 +41,7 @@ const LocalParticipant: React.FC<LocalParticipantProps> = (props) => {
   }
 
   return (
-    <DraggableCore handle=".handle" onDrag={dragEventHandler}>
+    <DraggableCore handle=".handle, path" onDrag={dragEventHandler}>
       <div className={classes.local}>
         <Participant {...props} />
       </div>

--- a/services/conference/src/scripts/components/map/ParticipantsLayer/LocalParticipant.tsx
+++ b/services/conference/src/scripts/components/map/ParticipantsLayer/LocalParticipant.tsx
@@ -2,8 +2,9 @@ import {useStore} from '@hooks/ParticipantsStore'
 import {memoComponent} from '@hooks/utils'
 import {makeStyles} from '@material-ui/core/styles'
 import {useObserver} from 'mobx-react-lite'
-import React, {useEffect, useRef} from 'react'
-import {addV, subV, useGesture} from 'react-use-gesture'
+import React from 'react'
+import {DraggableCore, DraggableData, DraggableEvent, DraggableEventHandler} from 'react-draggable'
+import {addV, subV} from 'react-use-gesture'
 import {useValue as useTransform} from '../utils/useTransform'
 import {Participant, ParticipantProps} from './Participant'
 
@@ -31,37 +32,20 @@ const LocalParticipant: React.FC<LocalParticipantProps> = (props) => {
 
   const transform = useTransform()
 
-  const container = useRef<HTMLDivElement>(null)
-
-  const bind = useGesture(
-    {
-      onDrag: ({down, delta, event}) => {
-        if (down) {
-          event?.stopPropagation()
-          event?.preventDefault()
-          participant.pose.position = addV(
-            subV(transform.global2Local(delta), transform.global2Local([0, 0])), participantProps.position)
-        }
-      },
-    },
-    {
-      domTarget: container,
-      eventOptions: {
-        passive: false,
-      },
-    },
-  )
-  useEffect(
-    () => {
-      bind()
-    },
-    [bind],
-  )
+  const dragEventHandler: DraggableEventHandler = (e: DraggableEvent, data: DraggableData) => {
+    e.stopPropagation()
+    e.preventDefault()
+    const delta: [number, number] = [data.deltaX, data.deltaY]
+    participant.pose.position = addV(
+      subV(transform.global2Local(delta), transform.global2Local([0, 0])), participantProps.position)
+  }
 
   return (
-    <div className={classes.local}>
-      <Participant {...props} ref={container} />
-    </div>
+    <DraggableCore handle=".handle" onDrag={dragEventHandler}>
+      <div className={classes.local}>
+        <Participant {...props} />
+      </div>
+    </DraggableCore>
   )
 }
 

--- a/services/conference/src/scripts/components/map/ParticipantsLayer/Participant.tsx
+++ b/services/conference/src/scripts/components/map/ParticipantsLayer/Participant.tsx
@@ -78,7 +78,7 @@ const RawParticipant: React.ForwardRefRenderFunction<HTMLDivElement , Participan
             <div className={classes.pointerRotate}>
               <Pointer className={classes.pointer} />
             </div>
-            <div className={[classes.avatar, transform.counterRotationClass, 'handle'].join(' ')}>
+            <div className={[classes.avatar, transform.counterRotationClass, 'draggableHandle'].join(' ')}>
               <Avatar {...props} />
             </div>
           </div>

--- a/services/conference/src/scripts/components/map/ParticipantsLayer/Participant.tsx
+++ b/services/conference/src/scripts/components/map/ParticipantsLayer/Participant.tsx
@@ -78,7 +78,7 @@ const RawParticipant: React.ForwardRefRenderFunction<HTMLDivElement , Participan
             <div className={classes.pointerRotate}>
               <Pointer className={classes.pointer} />
             </div>
-            <div className={[classes.avatar, transform.counterRotationClass].join(' ')}>
+            <div className={[classes.avatar, transform.counterRotationClass, 'handle'].join(' ')}>
               <Avatar {...props} />
             </div>
           </div>

--- a/services/conference/yarn.lock
+++ b/services/conference/yarn.lock
@@ -9682,6 +9682,14 @@ react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
+react-draggable@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.3.tgz#0727f2cae5813e36b0e4962bf11b2f9ef2b406f3"
+  integrity sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
+
 react-element-to-jsx-string@^14.0.2:
   version "14.3.1"
   resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.1.tgz#a08fa6e46eb76061aca7eabc2e70f433583cb203"


### PR DESCRIPTION
This PR reduces the drag start area for the local participant on the 2D map (see issue https://github.com/JitsiPartyTeam/jitsi-party/issues/26) by using the [react-draggable](https://github.com/STRML/react-draggable) package.

This package fits this task well because it provides a way to specify a selector for the "_handle_" element that would be used as the drag start area. I used the "pointer" and the avatar of the local participant as _handles_.