### PR TITLE
Feature/switch audio

### DIFF
--- a/services/conference/src/scripts/components/avatar/StreamAvatar.tsx
+++ b/services/conference/src/scripts/components/avatar/StreamAvatar.tsx
@@ -34,8 +34,6 @@ const setStream = (
   video.srcObject = stream
   video.autoplay = true
 
-  console.log('set stream')
-
   video.onloadedmetadata = () => {
     const settings = {
       width: video.width,
@@ -57,7 +55,6 @@ export const StreamAvatar: React.FC<StreamAvatarProps> = (props: StreamAvatarPro
 
   useEffect(
     () => {
-      console.log('use effect')
       if (videoRef !== null && videoRef.current !== null) {
         setStream(videoRef.current, props.stream, classes.videoLargerWidth, classes.videoLargerHeight)
       }

--- a/services/conference/src/scripts/components/footer/StereoAudioSwitch.tsx
+++ b/services/conference/src/scripts/components/footer/StereoAudioSwitch.tsx
@@ -1,0 +1,16 @@
+import {useStore as useParticipantsStore} from '@hooks/ParticipantsStore'
+import Fab from '@material-ui/core/Fab'
+import {useObserver} from 'mobx-react-lite'
+import React from 'react'
+
+export const StereoAudioSwitch: React.FunctionComponent = () => {
+  const participants = useParticipantsStore()
+  const stereo = useObserver(() => participants.local.get().useStereoAudio)
+
+  const switchStereo = () => {
+    participants.local.get().useStereoAudio = !stereo
+  }
+
+  return <Fab onClick={switchStereo}>{stereo ? 'Stereo' : 'Mono'}</Fab>
+}
+StereoAudioSwitch.displayName = 'StereoAudioSwtich'

--- a/services/conference/src/scripts/components/footer/footer.tsx
+++ b/services/conference/src/scripts/components/footer/footer.tsx
@@ -14,6 +14,7 @@ import SpeakerOffIcon from '@material-ui/icons/VolumeOff'
 import SpeakerOnIcon from '@material-ui/icons/VolumeUp'
 import {useObserver} from 'mobx-react-lite'
 import React from 'react'
+import {StereoAudioSwitch} from './StereoAudioSwitch'
 
 const useStyles = makeStyles((theme) => {
   return ({
@@ -160,6 +161,8 @@ export const Footer: React.FC<BaseProps> = (props) => {
         aria-label="share">
         <ScreenShareIcon />
       </Fab>
+
+      <StereoAudioSwitch />
    </div>
   )
 }

--- a/services/conference/src/scripts/models/audio/ConnectedManager.ts
+++ b/services/conference/src/scripts/models/audio/ConnectedManager.ts
@@ -28,6 +28,13 @@ export class ConnectedManager {
         this.manager.setAudioOutput(deviceId)
       },
     )
+
+    reaction(
+      () => store.local.get().useStereoAudio,
+      (useStereoAudio) => {
+        this.manager.switchPlayMode(useStereoAudio ? 'Context' : 'Element')
+      },
+    )
   }
 
   private onPopulationChange = () => {

--- a/services/conference/src/scripts/stores/participants/LocalParticipant.ts
+++ b/services/conference/src/scripts/stores/participants/LocalParticipant.ts
@@ -1,8 +1,11 @@
+import {observable} from 'mobx'
 import {DevicePreference} from './localPlugins'
 import {Participant} from './Participant'
 
 export class LocalParticipant extends Participant {
   devicePreference = new DevicePreference()
+
+  @observable useStereoAudio = true
 
   constructor(id: string) {
     super(id)


### PR DESCRIPTION
#18

**What is changed**
Enable switching audio to be:
- processed through audio context (with stereo sound)
- or directly output through audio elements (with echo cancellation enabled)

Note that latter have no stereo sound (even the volume would not decay by distance)

**How to test**
Please use the test button in footer to swtich between to output method:
![movement](https://user-images.githubusercontent.com/17405914/86730808-dec87680-c069-11ea-90c9-5761bb516254.gif)

Two participant join one conference. One(A) keeps speaking, another(B) switch audio output. 
In stereo, A could hear his own sound.
In mono, A could not hear his own sound. 
