### PR TITLE
Feature/add scroll bar to map

### DIFF
--- a/services/conference/src/scripts/components/footer/footer.tsx
+++ b/services/conference/src/scripts/components/footer/footer.tsx
@@ -26,18 +26,16 @@ const useStyles = makeStyles((theme) => {
       '&:hover': {
         opacity: 1.0,
       },
+      pointerEvents: 'none',
     },
     margin: {
       margin: theme.spacing(1),
+      pointerEvents: 'auto',
     },
     small: {
       transform: 'scale(0.5)',
       margin: '1.2em 0 0 -2.1em',
-    },
-    itemSelected: {
-      color: 'primary',
-    },
-    item:{
+      pointerEvents: 'auto',
     },
   })
 })

--- a/services/conference/src/scripts/components/map/BackgroundLayer/Background.tsx
+++ b/services/conference/src/scripts/components/map/BackgroundLayer/Background.tsx
@@ -1,31 +1,29 @@
-import {Base} from '@components/map/Base'
+import {MAP_SIZE} from '@components/map/Base'
 import jitsiIcon from '@images/jitsi/Poweredby_Jitsi_logo_white_04_2020_white.png'
 import {makeStyles} from '@material-ui/core/styles'
 import React from 'react'
-
-const SIZE = 5000
 
 const useStyles = makeStyles({
   img: (props:BackgroundProps) => {
     if (props.isTransparnet) {
       return  {
         position: 'absolute',
-        transform: `translate(-${SIZE / 2}px, -${SIZE / 2}px)`,
+//        transform: `translate(-${SIZE / 2}px, -${SIZE / 2}px)`,
         backgroundColor: 'rgba(0,0,0,0.1)',
         backgroundImage: `url("data:image/svg+xml,%3Csvg width='80' height='80' viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='rgba(255,255,255,0.1)' fill-opacity='0.4'%3E%3Cpath d='M50 50c0-5.523 4.477-10 10-10s10 4.477 10 10-4.477 10-10 10c0 5.523-4.477 10-10 10s-10-4.477-10-10 4.477-10 10-10zM10 10c0-5.523 4.477-10 10-10s10 4.477 10 10-4.477 10-10 10c0 5.523-4.477 10-10 10S0 25.523 0 20s4.477-10 10-10zm10 8c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8zm40 40c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8z' /%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
 
-        height: SIZE,
-        width: SIZE,
+        height: MAP_SIZE,
+        width: MAP_SIZE,
       }
     }
 
     return {
       position: 'absolute',
-      transform: `translate(-${SIZE / 2}px, -${SIZE / 2}px)`,
+//      transform: `translate(-${SIZE / 2}px, -${SIZE / 2}px)`,
       backgroundColor: '#DFDBE5',
       backgroundImage: `url("data:image/svg+xml,%3Csvg width='80' height='80' viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%239C92AC' fill-opacity='0.4'%3E%3Cpath d='M50 50c0-5.523 4.477-10 10-10s10 4.477 10 10-4.477 10-10 10c0 5.523-4.477 10-10 10s-10-4.477-10-10 4.477-10 10-10zM10 10c0-5.523 4.477-10 10-10s10 4.477 10 10-4.477 10-10 10c0 5.523-4.477 10-10 10S0 25.523 0 20s4.477-10 10-10zm10 8c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8zm40 40c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8z' /%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-      height: SIZE,
-      width: SIZE,
+      height: MAP_SIZE,
+      width: MAP_SIZE,
     }
   },
   logo: (props:BackgroundProps) => {

--- a/services/conference/src/scripts/components/map/BackgroundLayer/Background.tsx
+++ b/services/conference/src/scripts/components/map/BackgroundLayer/Background.tsx
@@ -8,10 +8,8 @@ const useStyles = makeStyles({
     if (props.isTransparnet) {
       return  {
         position: 'absolute',
-//        transform: `translate(-${SIZE / 2}px, -${SIZE / 2}px)`,
         backgroundColor: 'rgba(0,0,0,0.1)',
         backgroundImage: `url("data:image/svg+xml,%3Csvg width='80' height='80' viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='rgba(255,255,255,0.1)' fill-opacity='0.4'%3E%3Cpath d='M50 50c0-5.523 4.477-10 10-10s10 4.477 10 10-4.477 10-10 10c0 5.523-4.477 10-10 10s-10-4.477-10-10 4.477-10 10-10zM10 10c0-5.523 4.477-10 10-10s10 4.477 10 10-4.477 10-10 10c0 5.523-4.477 10-10 10S0 25.523 0 20s4.477-10 10-10zm10 8c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8zm40 40c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8z' /%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
-
         height: MAP_SIZE,
         width: MAP_SIZE,
       }
@@ -19,7 +17,6 @@ const useStyles = makeStyles({
 
     return {
       position: 'absolute',
-//      transform: `translate(-${SIZE / 2}px, -${SIZE / 2}px)`,
       backgroundColor: '#DFDBE5',
       backgroundImage: `url("data:image/svg+xml,%3Csvg width='80' height='80' viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%239C92AC' fill-opacity='0.4'%3E%3Cpath d='M50 50c0-5.523 4.477-10 10-10s10 4.477 10 10-4.477 10-10 10c0 5.523-4.477 10-10 10s-10-4.477-10-10 4.477-10 10-10zM10 10c0-5.523 4.477-10 10-10s10 4.477 10 10-4.477 10-10 10c0 5.523-4.477 10-10 10S0 25.523 0 20s4.477-10 10-10zm10 8c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8zm40 40c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8z' /%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
       height: MAP_SIZE,

--- a/services/conference/src/scripts/components/map/Base/Base.tsx
+++ b/services/conference/src/scripts/components/map/Base/Base.tsx
@@ -2,12 +2,11 @@ import {BaseProps as BP} from '@components/utils'
 import {useStore} from '@hooks/ParticipantsStore'
 import {makeStyles} from '@material-ui/core/styles'
 import {
-  assert, crossProduct, extractRotation, extractScaleX, multiply,
+  crossProduct, extractRotation, extractScaleX, multiply,
   radian2Degree, rotate90ClockWise, rotateVector2D, transformPoint2D, vectorLength,
 } from '@models/utils'
 import {useObserver} from 'mobx-react-lite'
 import React, {useEffect, useRef, useState} from 'react'
-import {useDimensions} from 'react-dimensions-hook'
 import {addV, subV, useGesture} from 'react-use-gesture'
 import {createValue, Provider as TransformProvider} from '../utils/useTransform'
 
@@ -49,30 +48,33 @@ const options = {
 
 export const Base: React.FC<BaseProps> = (props: BaseProps) => {
   const container = useRef<HTMLDivElement>(null)
-  const participants = useStore()
+  const outer = useRef<HTMLDivElement>(null)
+  function offset():[number, number] {
+    if (outer.current) {
+      return [outer.current.scrollLeft, outer.current.scrollTop]
+    }
 
-  const localParticipantPosition = useObserver(() => participants.local.get().pose.position)
+    return [0, 0]
+  }
+  const participants = useStore()
 
   const [mouse, setMouse] = useState<[number, number]>([0, 0])  // mouse position relative to outer container
   const [matrix, setMatrix] = useState<DOMMatrixReadOnly>(new DOMMatrixReadOnly())
-
   // changed only when event end, like drag end
   const [commitedMatrix, setCommitedMatrix] = useState<DOMMatrixReadOnly>(new DOMMatrixReadOnly())
-
   const [startDrag, setStartDrag] = useState(false)
+
+  const localParticipantPosition = useObserver(() => participants.local.get().pose.position)
 
   const MOUSE_RIGHT = 2
   const bind = useGesture(
     {
-      onDragStart: ({event}) => {
-        setStartDrag(true)
-      },
+      onDragStart: ({event}) => { setStartDrag(true) },
       onDrag: ({down, delta, event, xy, buttons}) => {
-        if (startDrag && down) {
+        if (startDrag && down && outer.current) {
           if (buttons === MOUSE_RIGHT) {  // right mouse drag - rotate map
             const center = transformPoint2D(matrix, localParticipantPosition)
-            const target = addV(subV(xy, getDivAnchor(container)), subV(MAP_CENTER, centerOfOuter()))
-            // console.log(`center:${center}  target:${target} divA:${getDivAnchor(container)}`)
+            const target:[number, number] = addV(xy, offset())
             const radius1 = subV(target, center)
             const radius2 = subV(radius1, delta)
 
@@ -111,7 +113,7 @@ export const Base: React.FC<BaseProps> = (props: BaseProps) => {
 
         const [md, ma] = memo
 
-        const center = subV(origin as [number, number], getDivAnchor(container))
+        const center = addV(origin as [number, number], offset())
 
         let scale = d / md
         scale = limitScale(Math.abs(extractScaleX(matrix)), scale)
@@ -138,27 +140,19 @@ export const Base: React.FC<BaseProps> = (props: BaseProps) => {
       },
       onWheelEnd: () => setCommitedMatrix(matrix),
       onMove: ({xy}) => {
-        setMouse(subV(xy, getDivAnchor(container)))
-        const xyOnMap  = transformPoint2D(matrix.inverse(), addV(subV(xy, getDivAnchor(container)), MAP_CENTER));
+        setMouse(addV(xy, offset()))
+        const xyOnMap  = transformPoint2D(matrix.inverse(), mouse);
         (global as any).mousePositionOnMap = xyOnMap
       },
     },
   )
-  const outerDim = useDimensions()
-  function centerOfOuter():[number, number] {
-    return [outerDim.dimensions.clientWidth /2, outerDim.dimensions.clientHeight /2]
-  }
-  let outer:HTMLElement|null = null
-  function outerRef(e:HTMLElement|null) {
-    outerDim.ref(e)
-    outer = e
-  }
   //  scroll to center
   useEffect(
     () => {
-      if (outer) {
+      if (outer.current) {
+        const elem = outer.current
         console.log('useEffect[outer] called')
-        outer.scrollTo((MAP_SIZE - outer?.clientWidth) /2, (MAP_SIZE - outer?.clientHeight) /2)
+        elem.scrollTo((MAP_SIZE - elem.clientWidth) /2, (MAP_SIZE - elem.clientHeight) /2)
       }
     },
     [outer],
@@ -166,18 +160,20 @@ export const Base: React.FC<BaseProps> = (props: BaseProps) => {
   // prevent show context menu with right mouse click
   useEffect(
     () => {
-      assert(outer !== null)
+      const cb = (e: Event) => { e.preventDefault() }
+      outer.current?.addEventListener('contextmenu', cb)
 
-      const cb = (e: Event) => {
-        e.preventDefault()
-
-        return false
-      }
-      outer?.addEventListener('contextmenu', cb)
-
-      return () => outer?.removeEventListener('contextmenu', cb)
+      return () => outer.current?.removeEventListener('contextmenu', cb)
     },
-    [outer],
+    [outer])
+  // prevent to scroll by wheel
+  useEffect(
+    () => {
+      window.document.body.addEventListener('wheel',
+                                            (event) => { event.preventDefault() },
+                                            {passive: false})
+    },
+    [],
   )
 
   const relativeMouse = matrix.inverse().transformPoint(new DOMPoint(...mouse))
@@ -187,10 +183,10 @@ export const Base: React.FC<BaseProps> = (props: BaseProps) => {
   }
   const classes = useStyles(styleProps)
 
-  const transfromValue = createValue(commitedMatrix, getDivAnchor(container))
+  const transfromValue = createValue(commitedMatrix, [0, 0])
 
   return (
-    <div className={[classes.root, props.className].join(' ')} ref={outerRef} {...bind()}>
+    <div className={[classes.root, props.className].join(' ')} ref={outer} {...bind()}>
     <TransformProvider value={transfromValue}>
     <div id="map-transform" className={classes.transform} ref={container}>
           {props.children}
@@ -215,12 +211,3 @@ function limitScale(currentScale: number, scale: number): number {
   return scale
 }
 
-function getDivAnchor(e: React.RefObject<HTMLDivElement>): [number, number] {
-  const div = e.current
-
-  if (div === null) {
-    return [0, 0]
-  }
-
-  return [div.offsetLeft, div.offsetTop]
-}

--- a/services/conference/src/scripts/components/map/ShareLayer/PastedContent.tsx
+++ b/services/conference/src/scripts/components/map/ShareLayer/PastedContent.tsx
@@ -23,15 +23,7 @@ export const PastedContent: React.FC<PastedContentProps> = (props:PastedContentP
         const imageFile = evt.clipboardData.items[0].getAsFile()
         if (imageFile) {
           uploadToGyazo(imageFile).then(({url, size}) => {
-            // console.log("mousePos:" + (global as any).mousePositionOnMap)
-            pasted.url = url
-            pasted.type = 'img'
-            pasted.size = size
-            const CENTER = 0.5
-            for (let i = 0; i < pasted.pose.position.length; i += 1) {
-              pasted.pose.position[i] = (global as any).mousePositionOnMap[i] - CENTER * pasted.size[i]
-            }
-            sharedContents.setPasted(pasted)
+            sharedContents.setPastedImage(url, size)
           })
         }
       }else if (evt.clipboardData.types.includes('text/plain')) {

--- a/services/conference/src/scripts/components/map/ShareLayer/PastedContent.tsx
+++ b/services/conference/src/scripts/components/map/ShareLayer/PastedContent.tsx
@@ -1,9 +1,7 @@
 import {uploadToGyazo} from '@models/api/Gyazo'
 import {SharedContent as ISharedContent} from '@models/SharedContent'
-import {default as participants} from '@stores/participants/Participants'
 import {SharedContent} from '@stores/sharedContents/SharedContent'
 import {default as sharedContents} from '@stores/sharedContents/SharedContents'
-import {image} from 'faker'
 import _ from 'lodash'
 import {useObserver} from 'mobx-react-lite'
 import React, {useEffect} from 'react'
@@ -58,6 +56,7 @@ export const PastedContent: React.FC<PastedContentProps> = (props:PastedContentP
           onPaste(event)
           event.preventDefault()
         },
+        {passive:false},
       )
     },
     [],

--- a/services/conference/src/scripts/stores/MapObject/index.ts
+++ b/services/conference/src/scripts/stores/MapObject/index.ts
@@ -1,10 +1,11 @@
+import {MAP_CENTER} from '@components/map/Base'
 import {MapObject as IMapObject, Perceptibility, Pose2DMap} from '@models/MapObject'
 import {IObservableObject} from 'mobx'
 import {shallowObservable, Store} from '../utils'
 
 export const defaultValue: IMapObject = {
   pose: {
-    position: [0, 0],
+    position: [MAP_CENTER[0], MAP_CENTER[1]],
     orientation: 0,
   },
   perceptibility: {

--- a/services/conference/src/scripts/stores/sharedContents/SharedContents.ts
+++ b/services/conference/src/scripts/stores/sharedContents/SharedContents.ts
@@ -1,11 +1,10 @@
-import {TheatersOutlined} from '@material-ui/icons'
 import {ParticipantContents as IParticipantContents, SharedContent as ISharedContent} from '@models/SharedContent'
 import {default as participantsStore} from '@stores/participants/Participants'
-import {diffMap} from '@stores/utils'
+import {diffMap, shallowObservable} from '@stores/utils'
 import {EventEmitter} from 'events'
 import {JitsiLocalTrack, JitsiTrack} from 'lib-jitsi-meet'
 import _ from 'lodash'
-import {computed, observable} from 'mobx'
+import {action, computed, observable} from 'mobx'
 import {SharedContent} from './SharedContent'
 
 function contentComp(a:ISharedContent, b:ISharedContent) {
@@ -71,6 +70,12 @@ export class SharedContents extends EventEmitter {
   //  contents by owner
   participants: Map<string, ParticipantContents> = new Map<string, ParticipantContents>()
   leavingParticipants: Map<string, ParticipantContents> = new Map<string, ParticipantContents>()
+
+  //  pasted content
+  @observable.ref pasted = new SharedContent()
+  @action setPasted(c:SharedContent) {
+    this.pasted = Object.assign({}, c)
+  }
 
   @computed get localParticipant(): ParticipantContents {
     if (!this.localId) { this.localId = participantsStore.localId }

--- a/services/conference/src/scripts/stores/sharedContents/SharedContents.ts
+++ b/services/conference/src/scripts/stores/sharedContents/SharedContents.ts
@@ -76,6 +76,24 @@ export class SharedContents extends EventEmitter {
   @action setPasted(c:SharedContent) {
     this.pasted = Object.assign({}, c)
   }
+  @action setPastedImage(url: string, size: [number, number]) {
+    // console.log("mousePos:" + (global as any).mousePositionOnMap)
+    const pasted = new SharedContent()
+    pasted.type = 'img'
+    pasted.url = url
+    const max = size[0] > size[1] ? size[0] : size [1]
+    if (max > 500) {
+      const scale = 500 / max
+      size[0] *= scale
+      size[1] *= scale
+    }
+    pasted.size = size
+    const CENTER = 0.5
+    for (let i = 0; i < pasted.pose.position.length; i += 1) {
+      pasted.pose.position[i] = (global as any).mousePositionOnMap[i] - CENTER * pasted.size[i]
+    }
+    this.setPasted(pasted)
+  }
 
   @computed get localParticipant(): ParticipantContents {
     if (!this.localId) { this.localId = participantsStore.localId }


### PR DESCRIPTION
Add scroll bar to escape from very large shared content. If map is covered by contents, user can not drag map and can not scroll the map. In such case scroll bar can be an alternative method to scroll.
Because scroll(x,y) does not accept negative number, I had to change origin of the map again; this time from center to left top. 
