### PR TITLE
remove DEFAULT_PANNER_NODE_CONFIG

### DIFF
--- a/services/conference/src/scripts/models/audio/ConnectedGroup.ts
+++ b/services/conference/src/scripts/models/audio/ConnectedGroup.ts
@@ -1,12 +1,10 @@
 import {convertToAudioCoordinate, getRelativePose} from '@models/utils'
+import {stereoParametersStore} from '@stores/AudioParameters'
 import {LocalParticipant} from '@stores/participants/LocalParticipant'
 import {RemoteParticipant} from '@stores/participants/RemoteParticipant'
 import {JitsiTrack} from 'lib-jitsi-meet'
 import {autorun, IObservableValue, IReactionDisposer} from 'mobx'
 import {NodeGroup} from './NodeGroup'
-
-import {stereoParametersStore} from '@stores/AudioParameters'
-import {ConfigurableProp} from '@stores/AudioParameters/StereoParameters'
 
 export class ConnectedGroup {
   private readonly disposers: IReactionDisposer[] = []
@@ -27,12 +25,8 @@ export class ConnectedGroup {
       },
     ))
 
-    const observedPannerKeys: ConfigurableProp[] =
-      ['coneInnerAngle', 'coneOuterAngle', 'coneOuterGain', 'distanceModel', 'maxDistance', 'distanceModel', 'panningModel', 'refDistance', 'rolloffFactor']
     this.disposers.push(autorun(
-      () => observedPannerKeys.forEach((key) => {
-        (group.pannerNode[key] as any) = stereoParametersStore[key]
-      }),
+      () => group.updatePannerConfig(stereoParametersStore),
     ))
   }
 

--- a/services/conference/src/scripts/models/audio/NodeGroup.ts
+++ b/services/conference/src/scripts/models/audio/NodeGroup.ts
@@ -1,5 +1,6 @@
-import {Pose3DAudio, PARTICIPANT_SIZE} from '@models/Participant'
+import {PARTICIPANT_SIZE, Pose3DAudio} from '@models/Participant'
 import {isChrome} from '@models/utils'
+import {ConfigurableParams, ConfigurableProp} from './StereoParameters'
 
 // NOTE Set default value will change nothing. Because value will be overwrite by store in ConnectedGroup
 const DEFAULT_PANNER_NODE_CONFIG: Partial<PannerNode> & {refDistance: number} = {
@@ -21,7 +22,7 @@ export class NodeGroup {
   private audioElement: HTMLAudioElement | undefined = undefined
 
   private readonly gainNode: GainNode
-  public readonly pannerNode: PannerNode
+  private readonly pannerNode: PannerNode
 
   private readonly context: AudioContext
   private playMode: PlayMode
@@ -76,12 +77,31 @@ export class NodeGroup {
     this.pannerNode.setOrientation(...pose.orientation)
   }
 
+  private _defaultPannerRefDistance = PARTICIPANT_SIZE
+  private set defaultPannerRefDistance(val: number) {
+    this._defaultPannerRefDistance = val
+    if (this.pannerNode.refDistance !== BROADCAST_DISTANCE) { // not in broadcast mode
+      this.pannerNode.refDistance = this._defaultPannerRefDistance
+    }
+  }
   updateBroadcast(broadcast: boolean) {
     if (!broadcast) {
-      this.pannerNode.refDistance = DEFAULT_PANNER_NODE_CONFIG.refDistance
+      this.pannerNode.refDistance = this._defaultPannerRefDistance
     } else {
       this.pannerNode.refDistance = BROADCAST_DISTANCE
     }
+  }
+
+  updatePannerConfig(config: ConfigurableParams) {
+    const observedPannerKeys: ConfigurableProp[] =
+      ['coneInnerAngle', 'coneOuterAngle', 'coneOuterGain', 'distanceModel', 'maxDistance', 'distanceModel', 'panningModel', 'refDistance', 'rolloffFactor']
+    observedPannerKeys.forEach((key) => {
+      if (key === 'refDistance') {
+        this.defaultPannerRefDistance = config['refDistance']
+      } else {
+        (this.pannerNode[key] as any) = config[key]
+      }
+    })
   }
 
   updateAudibility(audibility: boolean) {
@@ -115,10 +135,6 @@ export class NodeGroup {
 
   private createPannerNode(context: AudioContext) {
     const panner = context.createPanner()
-
-    for (const [key, value] of Object.entries(DEFAULT_PANNER_NODE_CONFIG)) {
-      (panner as any)[key] = value
-    }
 
     return panner
   }

--- a/services/conference/src/scripts/models/audio/StereoParameters.ts
+++ b/services/conference/src/scripts/models/audio/StereoParameters.ts
@@ -1,0 +1,4 @@
+export type ConfigurableParams = Pick<PannerNode, ConfigurableProp>
+
+export type ConfigurableProp = 'coneInnerAngle' | 'coneOuterAngle' | 'coneOuterGain' | 'distanceModel' |
+                         'maxDistance' | 'distanceModel' | 'panningModel' | 'refDistance' | 'rolloffFactor'

--- a/services/conference/src/scripts/stores/AudioParameters/StereoParameters.ts
+++ b/services/conference/src/scripts/stores/AudioParameters/StereoParameters.ts
@@ -1,3 +1,4 @@
+import {ConfigurableParams} from '@models/audio/StereoParameters'
 import {PARTICIPANT_SIZE} from '@models/Participant'
 import {action, computed, observable} from 'mobx'
 
@@ -33,7 +34,4 @@ export class StereoParameters implements ConfigurableParams {
   }
 }
 
-export type ConfigurableParams = Pick<PannerNode, ConfigurableProp>
 
-export type ConfigurableProp = 'coneInnerAngle' | 'coneOuterAngle' | 'coneOuterGain' | 'distanceModel' |
-                         'maxDistance' | 'distanceModel' | 'panningModel' | 'refDistance' | 'rolloffFactor'


### PR DESCRIPTION
For Node group. Use the value in stereo parameters store, rather than former DEFAULT_PANNER_NODE_CONFIG.