### PR TITLE
fix mute node group

### DIFF
--- a/services/conference/src/scripts/models/audio/NodeGroup.ts
+++ b/services/conference/src/scripts/models/audio/NodeGroup.ts
@@ -1,4 +1,4 @@
-import {Pose3DAudio, PARTICIPANT_SIZE} from '@models/Participant'
+import {PARTICIPANT_SIZE, Pose3DAudio} from '@models/Participant'
 import {isChrome} from '@models/utils'
 
 // NOTE Set default value will change nothing. Because value will be overwrite by store in ConnectedGroup
@@ -64,6 +64,8 @@ export class NodeGroup {
         console.error(`Unknown output: ${playMode}`)
         break
     }
+
+    this.updateAudibility(this.audibility)
   }
 
   updateStream(stream: MediaStream | undefined) {
@@ -84,12 +86,19 @@ export class NodeGroup {
     }
   }
 
+  private audibility = true
   updateAudibility(audibility: boolean) {
     if (audibility) {
       this.gainNode.connect(this.pannerNode)
     } else {
       this.gainNode.disconnect()
     }
+
+    if (this.audioElement) {
+      this.audioElement.muted = !audibility
+    }
+
+    this.audibility = audibility
   }
 
   disconnect() {
@@ -142,12 +151,6 @@ export class NodeGroup {
       }
 
       this.audioElement.srcObject = stream
-    }
-  }
-
-  setMute(muted:boolean) {
-    if (this.audioElement) {
-      this.audioElement.muted = muted
     }
   }
 }

--- a/services/conference/src/scripts/models/audio/StereoManager.ts
+++ b/services/conference/src/scripts/models/audio/StereoManager.ts
@@ -90,7 +90,7 @@ export class StereoManager {
   set audioOutputMuted(muted: boolean) {
     console.log('audioOutputMuted', muted)
     for (const id in this.nodes) {
-      this.nodes[id].setMute(muted)
+      this.nodes[id].updateAudibility(muted)
     }
     this.audioDestination.stream.getTracks().forEach((track) => { track.enabled = !muted })
   }

--- a/services/conference/src/scripts/models/audio/StereoManager.ts
+++ b/services/conference/src/scripts/models/audio/StereoManager.ts
@@ -90,7 +90,7 @@ export class StereoManager {
   set audioOutputMuted(muted: boolean) {
     console.log('audioOutputMuted', muted)
     for (const id in this.nodes) {
-      this.nodes[id].updateAudibility(muted)
+      this.nodes[id].updateAudibility(!muted)
     }
     this.audioDestination.stream.getTracks().forEach((track) => { track.enabled = !muted })
   }


### PR DESCRIPTION
In the scale of single node group. 
In the old way of mute, 
- the non-chrome stereo audio would not be muted because the source node is still connected to the audio context destination. 
- And the change of play mode would reset the mute state.