### PR TITLE
Fixed white avatar. Detect mute event on MediaStreamTrack and fallback to image avatar. 

### DIFF
--- a/services/conference/src/config.js
+++ b/services/conference/src/config.js
@@ -55,4 +55,21 @@ const config_alpha = {
   rtc:rtcConfig
 }
 
-const config = config_alpha
+const config_local = {
+  hosts: {
+    domain: 'meet.jitsi',
+    muc: 'muc.meet.jitsi',
+    focus: 'focus.meet.jitsi',
+  },
+//  openBridgeChannel: 'datachannel', // One of true, 'datachannel', or 'websocket'
+  bosh: 'https://172.30.80.1:8443/http-bind', // FIXME: use xep-0156 for that
+  clientNode: 'http://jitsi.org/jitsimeet',
+  focusUserJid: 'focus@auth.meet.jitsi',
+  channelLastN: -1,
+  p2p: {
+    enabled: false,
+  },
+  rtc:rtcConfig
+}
+
+const config = config_local

--- a/services/conference/src/scripts/models/api/Connection.ts
+++ b/services/conference/src/scripts/models/api/Connection.ts
@@ -757,6 +757,8 @@ class Connection extends EventEmitter {
     const pid = track.getParticipantId()
     if (track.isMainScreen && track.isMainScreen()) {
       //  console.log(`${track} videoType:${(track as any).videoType} added`)
+      track.getTrack().onmute = () => { sharedContents.mutedRemoteTracks.add(track) }
+      track.getTrack().onunmute = () => { sharedContents.mutedRemoteTracks.delete(track) }
       const tracks:Set<JitsiTrack> = new Set(sharedContents.remoteMainTracks.get(pid))
       tracks.add(track)
       sharedContents.remoteMainTracks.set(pid, tracks)
@@ -773,6 +775,8 @@ class Connection extends EventEmitter {
             trackLog('avatar track ${track} ended.')
             remote.tracks.avatar = undefined
           }
+          track.getTrack().onmute = () => { remote.tracks.onMuteChanged(track, true) }
+          track.getTrack().onunmute = () => { remote.tracks.onMuteChanged(track, false) }
         }
       }
     }

--- a/services/conference/src/scripts/stores/participants/ParticipantBase.ts
+++ b/services/conference/src/scripts/stores/participants/ParticipantBase.ts
@@ -3,6 +3,7 @@ import {
   Information, ParticipantBase as IParticipantBase, Physics, Tracks,
 } from '@models/Participant'
 import {MapObject} from '@stores/MapObject'
+import {setupMaster} from 'cluster'
 import {JitsiTrack} from 'lib-jitsi-meet'
 import {action, computed, observable} from 'mobx'
 import {getRandomColor, getRandomColorRGB, shallowObservable, Store} from '../utils'
@@ -62,8 +63,12 @@ export class ParticipantBase extends MapObject implements Store<IParticipantBase
 export class TracksStore<T extends JitsiTrack> implements Tracks<T>{
   @observable.ref audio:T|undefined = undefined
   @observable.ref avatar:T|undefined = undefined
-  @observable.ref screen:T[][] = []
+  @observable avatarOk = this.avatar ? !this.avatar.getTrack().muted : true
   @computed get audioStream() { return this.audio?.getOriginalStream() }
-  @computed get avatarStream() { return this.avatar?.getOriginalStream() }
-  @computed get screenStream() { return this.screen.map(tracks => tracks[0].getOriginalStream()) }
+  @computed get avatarStream() { return this.avatarOk ? this.avatar?.getOriginalStream() : undefined }
+  @action onMuteChanged(track: JitsiTrack, mute: boolean) {
+    if (track === this.avatar) {
+      this.avatarOk = !mute
+    }
+  }
 }

--- a/services/conference/src/scripts/stores/sharedContents/SharedContents.ts
+++ b/services/conference/src/scripts/stores/sharedContents/SharedContents.ts
@@ -40,6 +40,7 @@ export class SharedContents extends EventEmitter {
   //  Tracks for the MainScreen
   @observable.ref localMainTracks: Set<JitsiLocalTrack> = new Set()
   @observable.shallow remoteMainTracks: Map<string, Set<JitsiTrack>> = new Map()
+  @observable.shallow mutedRemoteTracks: Set<JitsiTrack> = new Set()
   @computed get mainStream(): MediaStream|undefined {
     let tracks:Set<JitsiTrack> = new Set()
     if (this.localMainTracks.size) {
@@ -55,6 +56,7 @@ export class SharedContents extends EventEmitter {
     if (tracks.size) {
       let stream:MediaStream|undefined = undefined
       for (const track of tracks) {
+        if (this.mutedRemoteTracks.has(track)) { continue }
         if (!stream) {
           stream = track.getOriginalStream()
         } else if (track.getOriginalStream() !== stream) {


### PR DESCRIPTION
Handle MeidaStreamTrack.onmute and onunmute to detect stop of video stream and change avatar and mainScreen display.